### PR TITLE
Add server test setup and env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 .env.local
 .env.development.local
 .env.test.local
-.env.production.local 
+.env.production.local

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,11 @@
+PORT=5001
+DB_NAME=portfolio_db
+DB_USER=username
+DB_PASSWORD=password
+DB_HOST=localhost
+DB_PORT=5432
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRES_IN=1d
+PLAID_ENV=sandbox
+PLAID_CLIENT_ID=your_plaid_client_id
+PLAID_SECRET=your_plaid_secret

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node src/test.js",
     "dev": "nodemon src/test.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "portfolio",
@@ -31,6 +31,11 @@
     "sequelize": "^6.31.0"
   },
   "devDependencies": {
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.22",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/server/src/test.js
+++ b/server/src/test.js
@@ -5,24 +5,16 @@ const sequelize = require('./config/database');
 const authRoutes = require('./routes/auth');
 const accountRoutes = require('./routes/accounts');
 
-// Debug logging
-console.log('Environment Variables:', {
-  PORT: process.env.PORT,
-  DB_NAME: process.env.DB_NAME,
-  DB_USER: process.env.DB_USER,
-  DB_PASSWORD: process.env.DB_PASSWORD ? '****' : undefined,
-  DB_HOST: process.env.DB_HOST,
-  DB_PORT: process.env.DB_PORT,
-  JWT_SECRET: process.env.JWT_SECRET ? '****' : undefined
-});
-
 const app = express();
 
 // CORS configuration
-app.use(cors({
-  origin: 'http://localhost:3000',
-  credentials: true
-}));
+app.use(
+  cors({
+    origin: 'http://localhost:3000',
+    credentials: true
+  })
+);
+
 
 // Middleware
 app.use(express.json());
@@ -80,4 +72,8 @@ async function startServer() {
   }
 }
 
-startServer(); 
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { app, startServer };

--- a/server/tests/app.test.js
+++ b/server/tests/app.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const { app } = require('../src/test');
+
+describe('API routes', () => {
+  test('GET /api/test returns status 200', async () => {
+    const res = await request(app).get('/api/test');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ message: 'API is working!' });
+  });
+});


### PR DESCRIPTION
## Summary
- provide server `.env.example`
- add Jest and supertest config
- export Express app in `src/test.js`
- add simple API test
- clean up repo by removing stray file

## Testing
- `npm test --silent` in `server` *(fails: jest not found)*
- `npm test --silent` in `client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb1794fd48333acadebae1f97b76b